### PR TITLE
Add parameter to allow setting spark-defaults for new clusters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ CLI Options
       bootstrap-action: include a bootstrap script (s3 path)
       cluster-id:       job flow id of existing cluster to submit to
       debug:            allow debugging of cluster
+      defaults:         spark-defaults configuration of the form key1=val1 key=val2
       dynamic-pricing:  allow sparksteps to determine best bid price for task nodes
       ec2-key:          name of the Amazon EC2 key pair
       ec2-subnet-id:    Amazon VPC subnet id

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -10,6 +10,7 @@ Prompt parameters:
   bootstrap-action: include a bootstrap script (s3 path)
   cluster-id:       job flow id of existing cluster to submit to
   debug:            allow debugging of cluster
+  defaults:         spark-defaults configuration of the form key1=val1 key=val2
   dynamic-pricing:  allow sparksteps to determine best bid price for task nodes
   ec2-key:          name of the Amazon EC2 key pair
   ec2-subnet-id:    Amazon VPC subnet id
@@ -76,6 +77,7 @@ def create_parser():
     parser.add_argument('--bootstrap-script')
     parser.add_argument('--cluster-id')
     parser.add_argument('--debug', action='store_true')
+    parser.add_argument('--defaults', nargs='*')
     parser.add_argument('--dynamic-pricing', action='store_true')
     parser.add_argument('--ec2-key')
     parser.add_argument('--ec2-subnet-id')

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -29,6 +29,7 @@ def parse_tags(raw_tags_list):
 
     return tags_dict_list
 
+
 def parse_conf(raw_conf_list):
     """Parse configuration items for spark-defaults."""
     conf_dict = {}
@@ -38,6 +39,7 @@ def parse_conf(raw_conf_list):
             key, value = raw_conf.split('=', 1)
             conf_dict[key] = value
     return(conf_dict)
+
 
 def emr_config(release_label, master, keep_alive=False, **kw):
     timestamp = datetime.datetime.now().replace(microsecond=0)

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -29,6 +29,15 @@ def parse_tags(raw_tags_list):
 
     return tags_dict_list
 
+def parse_conf(raw_conf_list):
+    """Parse configuration items for spark-defaults."""
+    conf_dict = {}
+
+    for raw_conf in raw_conf_list:
+        if "=" in raw_conf:
+            key, value = raw_conf.split('=', 1)
+            conf_dict[key] = value
+    return(conf_dict)
 
 def emr_config(release_label, master, keep_alive=False, **kw):
     timestamp = datetime.datetime.now().replace(microsecond=0)
@@ -85,6 +94,9 @@ def emr_config(release_label, master, keep_alive=False, **kw):
         config['Steps'] = [steps.DebugStep().step]
     if kw.get('tags'):
         config['Tags'] = parse_tags(kw['tags'])
+    if kw.get('defaults'):
+        config['Configurations'] = [{'Classification': 'spark-defaults',
+                                     'Properties': parse_conf(kw['defaults'])}]
     if kw.get('bootstrap_script'):
         config['BootstrapActions'] = [{'Name': 'bootstrap',
                                        'ScriptBootstrapAction': {'Path': kw['bootstrap_script']}}]

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -38,7 +38,7 @@ def parse_conf(raw_conf_list):
         if "=" in raw_conf:
             key, value = raw_conf.split('=', 1)
             conf_dict[key] = value
-    return(conf_dict)
+    return conf_dict
 
 
 def emr_config(release_label, master, keep_alive=False, **kw):

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -175,6 +175,7 @@ def test_parser():
       --app-args="--input /home/hadoop/episodes.avro" \
       --num-core 1 \
       --tags Name=MyName CostCenter=MyCostCenter \
+      --defaults key=value another_key=another_value \
       --debug
     """
     args = parser.parse_args(shlex.split(cmd_args_str))
@@ -182,6 +183,7 @@ def test_parser():
     assert args.s3_bucket == 'my-bucket'
     assert args.app_args == ['--input', '/home/hadoop/episodes.avro']
     assert args.debug is True
+    assert args.defaults == ['key=value', 'another_key=another_value']
     assert args.master == 'm4.large'
     assert args.release_label == 'emr-4.7.0'
     assert args.submit_args == ['--jars',
@@ -201,6 +203,7 @@ def test_parser_with_bootstrap():
       --app-args="--input /home/hadoop/episodes.avro" \
       --num-core 1 \
       --tags Name=MyName CostCenter=MyCostCenter \
+      --defaults key=value another_key=another_value \
       --bootstrap-script s3://bucket/bootstrap-actions.sh \
       --debug
     """
@@ -209,6 +212,7 @@ def test_parser_with_bootstrap():
     assert args.s3_bucket == 'my-bucket'
     assert args.app_args == ['--input', '/home/hadoop/episodes.avro']
     assert args.debug is True
+    assert args.defaults == ['key=value', 'another_key=another_value']
     assert args.master == 'm4.large'
     assert args.release_label == 'emr-4.7.0'
     assert args.submit_args == ['--jars',


### PR DESCRIPTION
This PR includes the necessary changes to allow new clusters to be created with spark-defaults configuration as described in the AWS docs [here](http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-configure.html#spark-defaults). This is a very basic implementation that takes key=value pairs as input. 

Future improvements could include feeding this option using a .json file instead and/or removing the hardcoded spark-defaults classification so that configuration files like yarn-env, hadoop-env etc. can also be configured this way. 

Thank you for this very helpful tool!