### PR TITLE
return add_job_flow_steps response to log step ids

### DIFF
--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -139,7 +139,7 @@ def main():
     response = client.add_job_flow_steps(JobFlowId=cluster_id, Steps=emr_steps)
 
     try:
-        step_ids = json.dumps(response["StepIds"])
-    except TypeError:
-        step_ids = "Invalid response"
-    logger.info("Step IDs: %s" % step_ids)
+        step_ids = json.dumps(response['StepIds'])
+    except KeyError:
+        step_ids = 'Invalid response'
+    logger.info("Step IDs: %s", step_ids)

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -43,6 +43,7 @@ Examples:
 """
 from __future__ import print_function
 
+import json
 import os
 import shlex
 import logging
@@ -135,4 +136,10 @@ def main():
                                   args.uploads,
                                   args.s3_dist_cp)
 
-    client.add_job_flow_steps(JobFlowId=cluster_id, Steps=emr_steps)
+    response = client.add_job_flow_steps(JobFlowId=cluster_id, Steps=emr_steps)
+
+    try:
+        step_ids = json.dumps(response["StepIds"])
+    except TypeError:
+        step_ids = "Invalid response"
+    logger.info("Step IDs: %s" % step_ids)


### PR DESCRIPTION
We include jobs initialized by sparksteps in scheduled pipelines with many components. For this purpose, it would be convenient for us to have sparksteps return the Step ID's that it generates to have this information available in subsequent stages of the pipeline. 

This small PR adds logging of the step id's to the console. I've used json.dumps() here so the unicode strings are not prefix'd with a 'u' character on Python 2. The accompanying try/except might not be the best safety check compared to alternative methods like [this one](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/operators/emr_add_steps_operator.py#L57), but I'll be happy to write in whichever you see fit. Thanks in advance. 