### PR TITLE
Add Maximize Resource Allocation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,31 +26,32 @@ CLI Options
 ::
 
     Prompt parameters:
-      app               main spark script for submit spark (required)
-      app-args:         arguments passed to main spark script
-      aws-region:       AWS region name
-      bid-price:        specify bid price for task 
-      bootstrap-action: include a bootstrap script (s3 path)
-      cluster-id:       job flow id of existing cluster to submit to
-      debug:            allow debugging of cluster
-      defaults:         spark-defaults configuration of the form key1=val1 key=val2
-      dynamic-pricing:  allow sparksteps to determine best bid price for task nodes
-      ec2-key:          name of the Amazon EC2 key pair
-      ec2-subnet-id:    Amazon VPC subnet id
-      help (-h):        argparse help
-      keep-alive:       Keep EMR cluster alive when no steps
-      master:           instance type of of master host (default='m4.large')
-      name:             specify cluster name
-      num-core:         number of core nodes
-      num-task:         number of task nodes
-      release-label:    EMR release label
-      s3-bucket:        name of s3 bucket to upload spark file (required)
-      s3-dist-cp:       s3-dist-cp step after spark job is done
-      slave:            instance type of of slave hosts
-      submit-args:      arguments passed to spark-submit
-      sparksteps-conf:  use sparksteps Spark conf
-      tags:             EMR cluster tags of the form "key1=value1 key2=value2"
-      uploads:          files to upload to /home/hadoop/ in master instance
+      app                           main spark script for submit spark (required)
+      app-args:                     arguments passed to main spark script
+      aws-region:                   AWS region name
+      bid-price:                    specify bid price for task 
+      bootstrap-action:             include a bootstrap script (s3 path)
+      cluster-id:                   job flow id of existing cluster to submit to
+      debug:                        allow debugging of cluster
+      defaults:                     spark-defaults configuration of the form key1=val1 key=val2
+      dynamic-pricing:              allow sparksteps to determine best bid price for task nodes
+      ec2-key:                      name of the Amazon EC2 key pair
+      ec2-subnet-id:                Amazon VPC subnet id
+      help (-h):                    argparse help
+      keep-alive:                   Keep EMR cluster alive when no steps
+      master:                       instance type of of master host (default='m4.large')
+      name:                         specify cluster name
+      num-core:                     number of core nodes
+      num-task:                     number of task nodes
+      release-label:                EMR release label
+      s3-bucket:                    name of s3 bucket to upload spark file (required)
+      s3-dist-cp:                   s3-dist-cp step after spark job is done
+      slave:                        instance type of of slave hosts
+      submit-args:                  arguments passed to spark-submit
+      sparksteps-conf:              use sparksteps Spark conf
+      tags:                         EMR cluster tags of the form "key1=value1 key2=value2"
+      uploads:                      files to upload to /home/hadoop/ in master instance
+      maximize-resource-allocation: Sets the maximizeResourceAllocation property for the cluster to true when supplied.
 
 Example
 -------

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -122,9 +122,9 @@ def main():
             bid_px, is_spot = pricing.get_bid_price(ec2, args.slave)
             args_dict['bid_price'] = str(bid_px)
             if is_spot:
-                logger.info("Using spot pricing with bid price $%d", bid_px)
+                logger.info("Using spot pricing with bid price $%.2f", bid_px)
             else:
-                logger.info("Spot price too high. Using on-demand %d", bid_px)
+                logger.info("Spot price too high. Using on-demand price of $%.2f", bid_px)
         cluster_config = cluster.emr_config(**args_dict)
         response = client.run_job_flow(**cluster_config)
         cluster_id = response['JobFlowId']

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -3,31 +3,32 @@
 """Create Spark cluster on EMR.
 
 Prompt parameters:
-  app               main spark script for submit spark (required)
-  app-args:         arguments passed to main spark script
-  aws-region:       AWS region name
-  bid-price:        specify bid price for task nodes
-  bootstrap-action: include a bootstrap script (s3 path)
-  cluster-id:       job flow id of existing cluster to submit to
-  debug:            allow debugging of cluster
-  defaults:         spark-defaults configuration of the form key1=val1 key=val2
-  dynamic-pricing:  allow sparksteps to determine best bid price for task nodes
-  ec2-key:          name of the Amazon EC2 key pair
-  ec2-subnet-id:    Amazon VPC subnet id
-  help (-h):        argparse help
-  keep-alive:       Keep EMR cluster alive when no steps
-  log-level (-l)    logging level (default=INFO)
-  master:           instance type of of master host (default='m4.large')
-  name:             specify cluster name
-  num-core:         number of core nodes
-  num-task:         number of task nodes
-  release-label:    EMR release label
-  s3-bucket:        name of s3 bucket to upload spark file (required)
-  s3-dist-cp:       s3-dist-cp step after spark job is done
-  slave:            instance type of of slave hosts
-  submit-args:      arguments passed to spark-submit
-  tags:             EMR cluster tags of the form "key1=value1 key2=value2"
-  uploads:          files to upload to /home/hadoop/ in master instance
+  app                           main spark script for submit spark (required)
+  app-args:                     arguments passed to main spark script
+  aws-region:                   AWS region name
+  bid-price:                    specify bid price for task nodes
+  bootstrap-action:             include a bootstrap script (s3 path)
+  cluster-id:                   job flow id of existing cluster to submit to
+  debug:                        allow debugging of cluster
+  defaults:                     spark-defaults configuration of the form key1=val1 key=val2
+  dynamic-pricing:              allow sparksteps to determine best bid price for task nodes
+  ec2-key:                      name of the Amazon EC2 key pair
+  ec2-subnet-id:                Amazon VPC subnet id
+  help (-h):                    argparse help
+  keep-alive:                   Keep EMR cluster alive when no steps
+  log-level (-l)                logging level (default=INFO)
+  master:                       instance type of of master host (default='m4.large')
+  name:                         specify cluster name
+  num-core:                     number of core nodes
+  num-task:                     number of task nodes
+  release-label:                EMR release label
+  s3-bucket:                    name of s3 bucket to upload spark file (required)
+  s3-dist-cp:                   s3-dist-cp step after spark job is done
+  slave:                        instance type of of slave hosts
+  submit-args:                  arguments passed to spark-submit
+  tags:                         EMR cluster tags of the form "key1=value1 key2=value2"
+  uploads:                      files to upload to /home/hadoop/ in master instance
+  maximize-resource-allocation: Sets the maximizeResourceAllocation property for the cluster to true when supplied.
 
 Examples:
   sparksteps examples/episodes.py \
@@ -95,6 +96,7 @@ def create_parser():
     parser.add_argument('--submit-args', type=shlex.split)
     parser.add_argument('--tags', nargs='*')
     parser.add_argument('--uploads', nargs='*')
+    parser.add_argument('--maximize-resource-allocation', action='store_true')
 
     return parser
 

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -99,6 +99,13 @@ def emr_config(release_label, master, keep_alive=False, **kw):
     if kw.get('defaults'):
         config['Configurations'] = [{'Classification': 'spark-defaults',
                                      'Properties': parse_conf(kw['defaults'])}]
+    if kw.get('maximize_resource_allocation'):
+        configurations = config.get('Configurations', [])
+        configurations.append({
+            'Classification': 'spark',
+            'Properties': {'maximizeResourceAllocation': 'true'}
+        })
+        config['Configurations'] = configurations
     if kw.get('bootstrap_script'):
         config['BootstrapActions'] = [{'Name': 'bootstrap',
                                        'ScriptBootstrapAction': {'Path': kw['bootstrap_script']}}]

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -29,6 +29,7 @@ def test_emr_cluster_config():
                         num_core=1,
                         num_task=1,
                         bid_price='0.1',
+                        maximize_resource_allocation=True,
                         name="Test SparkSteps")
     assert config == {'Instances':
                           {'InstanceGroups': [{'InstanceCount': 1,  # NOQA: E127
@@ -55,7 +56,10 @@ def test_emr_cluster_config():
                       'JobFlowRole': 'EMR_EC2_DefaultRole',
                       'ReleaseLabel': 'emr-5.2.0',
                       'VisibleToAllUsers': True,
-                      'ServiceRole': 'EMR_DefaultRole'}
+                      'ServiceRole': 'EMR_DefaultRole',
+                      'Configurations': [{'Classification': 'spark',
+                                          'Properties': {'maximizeResourceAllocation': 'true'}}]
+                      }
 
     client = boto3.client('emr', region_name=AWS_REGION_NAME)
     client.run_job_flow(**config)
@@ -176,6 +180,7 @@ def test_parser():
       --num-core 1 \
       --tags Name=MyName CostCenter=MyCostCenter \
       --defaults key=value another_key=another_value \
+      --maximize-resource-allocation \
       --debug
     """
     args = parser.parse_args(shlex.split(cmd_args_str))
@@ -190,6 +195,7 @@ def test_parser():
                                 '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
     assert args.uploads == ['examples/dir', 'examples/episodes.avro']
     assert args.tags == ['Name=MyName', 'CostCenter=MyCostCenter']
+    assert args.maximize_resource_allocation is True
 
 
 def test_parser_with_bootstrap():


### PR DESCRIPTION
This PR updates sparksteps such that the [maximizeResourceAllocation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-configure.html#emr-spark-maximizeresourceallocation) feature can be used from the commandline when invoking `sparksteps`.