### PR TITLE
Added support for specifying EBS volumes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,14 @@ CLI Options
       dynamic-pricing-master:       use spot pricing for the master nodes.
       dynamic-pricing-core:         use spot pricing for the core nodes.
       dynamic-pricing-task:         use spot pricing for the task nodes.
+      ebs-volume-size-core:         size of the EBS volume to attach to core nodes in GiB.
+      ebs-volume-type-core:         type of the EBS volume to attach to core nodes (supported: [standard, gp2, io1]).
+      ebs-volumes-per-core:         the number of EBS volumes to attach per core node.
+      ebs-optimized-core:           whether to use EBS optimized volumes for core nodes.
+      ebs-volume-size-task:         size of the EBS volume to attach to task nodes in GiB.
+      ebs-volume-type-task:         type of the EBS volume to attach to task nodes.
+      ebs-volumes-per-task:         the number of EBS volumes to attach per task node.
+      ebs-optimized-task:           whether to use EBS optimized volumes for task nodes.
       ec2-key:                      name of the Amazon EC2 key pair
       ec2-subnet-id:                Amazon VPC subnet id
       help (-h):                    argparse help

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -14,6 +14,14 @@ Prompt parameters:
   dynamic-pricing-master:       use spot pricing for the master nodes.
   dynamic-pricing-core:         use spot pricing for the core nodes.
   dynamic-pricing-task:         use spot pricing for the task nodes.
+  ebs-volume-size-core:         size of the EBS volume to attach to core nodes in GiB.
+  ebs-volume-type-core:         type of the EBS volume to attach to core nodes (supported: [standard, gp2, io1]).
+  ebs-volumes-per-core:         the number of EBS volumes to attach per core node.
+  ebs-optimized-core:           whether to use EBS optimized volumes for core nodes.
+  ebs-volume-size-task:         size of the EBS volume to attach to task nodes in GiB.
+  ebs-volume-type-task:         type of the EBS volume to attach to task nodes.
+  ebs-volumes-per-task:         the number of EBS volumes to attach per task node.
+  ebs-optimized-task:           whether to use EBS optimized volumes for task nodes.
   ec2-key:                      name of the Amazon EC2 key pair
   ec2-subnet-id:                Amazon VPC subnet id
   help (-h):                    argparse help
@@ -104,6 +112,17 @@ def create_parser():
     parser.add_argument('--dynamic-pricing-master', action='store_true')
     parser.add_argument('--dynamic-pricing-core', action='store_true')
     parser.add_argument('--dynamic-pricing-task', action='store_true')
+
+    # EBS configuration
+    parser.add_argument('--ebs-volume-size-core', type=int)
+    parser.add_argument('--ebs-volume-type-core', type=str, default='standard')
+    parser.add_argument('--ebs-volumes-per-core', type=int, default=1)
+    parser.add_argument('--ebs-optimized-core', action='store_true')
+
+    parser.add_argument('--ebs-volume-size-task', type=int)
+    parser.add_argument('--ebs-volume-type-task', type=str, default='standard')
+    parser.add_argument('--ebs-volumes-per-task', type=int, default=1)
+    parser.add_argument('--ebs-optimized-task', action='store_true')
 
     # Deprecated arguments
     parser.add_argument('--master')

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -81,6 +81,20 @@ def emr_config(release_label, keep_alive=False, **kw):
         if bid_price:
             instance_group_config['Market'] = 'SPOT'
             instance_group_config['BidPrice'] = bid_price
+
+        ebs_volume_size = kw.get('ebs_volume_size_{}'.format(instance_group), 0)
+        if ebs_volume_size > 0:
+            ebs_configuration = {
+                'EbsBlockDeviceConfigs': [{
+                    'VolumeSpecification': {
+                        'VolumeType': kw.get('ebs_volume_type_{}'.format(instance_group)),
+                        'SizeInGB': ebs_volume_size
+                    },
+                    'VolumesPerInstance': kw.get('ebs_volumes_per_{}'.format(instance_group), 1)
+                }],
+                'EbsOptimized': kw.get('ebs_optimized_{}'.format(instance_group), False)
+            }
+            instance_group_config['EbsConfiguration'] = ebs_configuration
         config['Instances']['InstanceGroups'].append(instance_group_config)
 
     if kw.get('name'):


### PR DESCRIPTION
This PR adds command line options to sparksteps for specifying configuration options for EBS volumes. This allows users of sparksteps to attach more disk space to instances in both the core and task instance groups.

See the AWS [blog](https://aws.amazon.com/blogs/aws/amazon-emr-update-support-for-ebs-volumes-and-m4-c4-instance-types/) for more information.