### PR TITLE
Fix TypeError raised when --ebs-volume-size-* is not set

### DIFF
--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -106,6 +106,7 @@ def create_parser():
     parser.add_argument('--tags', nargs='*')
     parser.add_argument('--uploads', nargs='*')
     parser.add_argument('--maximize-resource-allocation', action='store_true')
+    # TODO: wrap lines below in a for loop?
     parser.add_argument('--instance-type-master', default='m4.large')
     parser.add_argument('--instance-type-core')
     parser.add_argument('--instance-type-task')
@@ -114,12 +115,12 @@ def create_parser():
     parser.add_argument('--dynamic-pricing-task', action='store_true')
 
     # EBS configuration
-    parser.add_argument('--ebs-volume-size-core', type=int)
+    parser.add_argument('--ebs-volume-size-core', type=int, default=0)
     parser.add_argument('--ebs-volume-type-core', type=str, default='standard')
     parser.add_argument('--ebs-volumes-per-core', type=int, default=1)
     parser.add_argument('--ebs-optimized-core', action='store_true')
 
-    parser.add_argument('--ebs-volume-size-task', type=int)
+    parser.add_argument('--ebs-volume-size-task', type=int, default=0)
     parser.add_argument('--ebs-volume-type-task', type=str, default='standard')
     parser.add_argument('--ebs-volumes-per-task', type=int, default=1)
     parser.add_argument('--ebs-optimized-task', action='store_true')

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -83,7 +83,7 @@ def emr_config(release_label, keep_alive=False, **kw):
             instance_group_config['BidPrice'] = bid_price
 
         ebs_volume_size = kw.get('ebs_volume_size_{}'.format(instance_group), 0)
-        if ebs_volume_size > 0:
+        if ebs_volume_size:
             ebs_configuration = {
                 'EbsBlockDeviceConfigs': [{
                     'VolumeSpecification': {


### PR DESCRIPTION
Fixed a ValueError being raised at L86 in sparksteps/cluster.py due to the default being `None`.
This bug was accidentally introduced in fb2b194.