### PR TITLE
Fix get_demand_price

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,6 @@ determine bid price. That said, if the current spot price is over 80% of
 the on-demand cost, then on-demand instances are used to be
 conservative.
 
-Note: code depends on `ec2instances <http://www.ec2instances.info/>`__
-for getting demand price.
 
 Testing
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file=README.rst
 test=pytest
 
 [tool:pytest]
-addopts=-vv --flake8
+addopts=-vv --flake8 -m 'not integration'
 
 [flake8]
 max-line-length=120

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'pytest',
         'pytest-flake8',
         'moto',
+        'google-compute-engine'
     ],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
     keywords='aws emr pyspark spark boto'.split(),
     license='Apache License 2.0',
     install_requires=[
-        'boto3>=1.3.1',
-        'beautifulsoup4>=4.4.1',
-        'six>=1.10.0'
+        'boto3>=1.3.1'
     ],
     setup_requires=[
         'pytest-runner',

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,49 @@
+"""
+Unit/Integration Tests for the pricing module.
+
+Integration Tests (i.e tests that perform actual queries / make HTTP requests)
+ are marked appropriately using PyTest markers.
+"""
+import pytest
+
+import boto3
+
+from sparksteps.pricing import get_bid_price, get_demand_price
+
+# The price for an m4.large on-demand Linux instance in us-east-1.
+M4_LARGE_OD_PRICE = 0.100000
+
+
+@pytest.fixture
+def ec2():
+    """
+    In order to test pricing mechanics, we need to be able to make actual requests AWS.
+    Since we're actually communicating with AWS here this makes this tests using this fixture
+     more of an integration test than a unit test.
+    """
+    client = boto3.client('ec2')
+    return client
+
+
+@pytest.fixture
+def pricing_client():
+    """
+    Boto3 Pricing Client.
+    """
+    return boto3.client('pricing')
+
+
+@pytest.mark.integration
+class TestPricing:
+    def test_get_demand_price(self, pricing_client):
+        price = get_demand_price(pricing_client, 'm4.large')
+        # Note: this test assumes that AWS doesn't
+        # change their on-demand price.
+        assert price == M4_LARGE_OD_PRICE
+
+    def test_get_bid_price(self, ec2, pricing_client):
+        bid_price, is_spot = get_bid_price(ec2, pricing_client, 'm4.large')
+        if is_spot:
+            assert bid_price > 0.
+        else:
+            assert bid_price == get_demand_price('us-east-1', 'm4.large')


### PR DESCRIPTION
ec2instances.info started returning GZIP encoded data, which would not
be decoded by six.moves.urllib.request.urlopen. I figured we'd be better
off by just fetching pricing data from Amazon.