### PR TITLE
Support arbitrary cluster default configuration classifications

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,11 @@
 Changelog
 =========
 
-- v1.0.0: Dropped support for Python 2
-- v1.0.0: `defaults` CLI parameter value schema changed to support arbitrary classifications
+v1.0.0 (2019-07-03)
+~~~~~~~~~~~~~~~~~~~
+
+* Dropped support for Python 2
+* `defaults` CLI parameter value schema changed to support arbitrary classifications
 
 Releases
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 Changelog
 =========
 
+- v1.0.0: Dropped support for Python 2
+- v1.0.0: `defaults` CLI parameter value schema changed to support arbitrary classifications
+
 Releases
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ CLI Options
       bootstrap-action:             include a bootstrap script (s3 path)
       cluster-id:                   job flow id of existing cluster to submit to
       debug:                        allow debugging of cluster
-      defaults:                     spark-defaults configuration of the form key1=val1 key=val2
+      defaults:                     cluster configurations of the form "<classification1> key1=val1 key2=val2 ..."
       dynamic-pricing-master:       use spot pricing for the master nodes.
       dynamic-pricing-core:         use spot pricing for the core nodes.
       dynamic-pricing-task:         use spot pricing for the task nodes.

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -10,7 +10,7 @@ Prompt parameters:
   bootstrap-action:             include a bootstrap script (s3 path)
   cluster-id:                   job flow id of existing cluster to submit to
   debug:                        allow debugging of cluster
-  defaults:                     spark-defaults configuration of the form key1=val1 key=val2
+  defaults:                     cluster configurations of the form "<classification1> key1=val1 key2=val2 ..."
   dynamic-pricing-master:       use spot pricing for the master nodes.
   dynamic-pricing-core:         use spot pricing for the core nodes.
   dynamic-pricing-task:         use spot pricing for the task nodes.


### PR DESCRIPTION
This PR updates the `defaults` CLI option in a backwards-incompatible way to support arbitrary EMR cluster configuration classifications.

Before, the only classification that could be set was `spark-defaults`. After this PR is merged and released (new major version), any arbitrary classification can be used.

The value for `defaults` should follow the form: 
```
--defaults <classification1> key1=value1 key2=value2 ... <classification2> key3=value3 ...
```

Example:
```
--defaults spark maximizeResourceAllocation=true spark-defaults spark.speculation=false
```
The above will generate a configurations dictionary of the form:
```
{
      'Configurations': [
            {
                  'Classification': 'spark',
                  'Properties': {
                        'maximizeResourceAllocation': 'true'
                  }
            },
            {
                  'Classification': 'spark-defaults',
                  'Properties': {
                        'spark.speculation': 'false'
                  }
            }
      ],
}
```

This feature is necessary to support AWS GLUE as a metastore which requires defining a few hive-site options to work.