### PR TITLE
Additional CLI parameters to configure cluster apps and EC2 role

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Changelog
 Releases
 --------
 
+v1.1.0 (2019-07-13)
+~~~~~~~~~~~~~~~~~~~
+
+* Added `jobflow_role` CLI argument to configure cluster EC2 Instance Profile
+* Added `app-list` CLI argument to configure list of Applications installed on cluster
+
+
 v1.0.0 (2019-07-03)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,15 +9,15 @@ Releases
 v1.1.0 (2019-07-13)
 ~~~~~~~~~~~~~~~~~~~
 
-* Added `jobflow_role` CLI argument to configure cluster EC2 Instance Profile
-* Added `app-list` CLI argument to configure list of Applications installed on cluster
+* Add `jobflow_role` CLI argument to configure cluster EC2 Instance Profile
+* Add `app-list` CLI argument to configure list of Applications installed on cluster
 
 
 v1.0.0 (2019-07-03)
 ~~~~~~~~~~~~~~~~~~~
 
-* Dropped support for Python 2
-* `defaults` CLI parameter value schema changed to support arbitrary classifications
+* Drop support for Python 2
+* `defaults` CLI parameter value schema to support arbitrary classifications
 
 
 v0.4.0 (2017-01-03)

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ CLI Options
     Prompt parameters:
       app                           main spark script for submit spark (required)
       app-args:                     arguments passed to main spark script
+      app-list:                     Space delimited list of applications to be installed on the EMR cluster (Default: Hadoop Spark)
       aws-region:                   AWS region name
       bid-price:                    specify bid price for task nodes
       bootstrap-action:             include a bootstrap script (s3 path)
@@ -48,6 +49,7 @@ CLI Options
       ec2-key:                      name of the Amazon EC2 key pair
       ec2-subnet-id:                Amazon VPC subnet id
       help (-h):                    argparse help
+      jobflow-role:                 Amazon EC2 instance profile name to use (Default: EMR_EC2_DefaultRole)
       keep-alive:                   whether to keep the EMR cluster alive when there are no steps
       log-level (-l):               logging level (default=INFO)
       instance-type-master:         instance type of of master host (default='m4.large')

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -69,7 +69,7 @@ import boto3
 from sparksteps import steps
 from sparksteps import cluster
 from sparksteps import pricing
-from sparksteps.defaults import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
+from sparksteps.cluster import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
 
 logger = logging.getLogger(__name__)
 LOGFORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -5,6 +5,7 @@
 Prompt parameters:
   app                           main spark script for submit spark (required)
   app-args:                     arguments passed to main spark script
+  app-list:                     Applications to be installed on the EMR cluster (Default: Hadoop Spark)
   aws-region:                   AWS region name
   bid-price:                    specify bid price for task nodes
   bootstrap-action:             include a bootstrap script (s3 path)
@@ -25,6 +26,7 @@ Prompt parameters:
   ec2-key:                      name of the Amazon EC2 key pair
   ec2-subnet-id:                Amazon VPC subnet id
   help (-h):                    argparse help
+  jobflow-role:                 Amazon EC2 instance profile name to use (Default: EMR_EC2_DefaultRole)
   keep-alive:                   whether to keep the EMR cluster alive when there are no steps
   log-level (-l):               logging level (default=INFO)
   instance-type-master:         instance type of of master host (default='m4.large')
@@ -67,6 +69,7 @@ import boto3
 from sparksteps import steps
 from sparksteps import cluster
 from sparksteps import pricing
+from sparksteps.defaults import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
 
 logger = logging.getLogger(__name__)
 LOGFORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
@@ -86,6 +89,7 @@ def create_parser():
 
     parser.add_argument('app', metavar='FILE')
     parser.add_argument('--app-args', type=shlex.split)
+    parser.add_argument('--app-list', nargs='*', default=DEFAULT_APP_LIST)
     parser.add_argument('--aws-region', required=True)
     parser.add_argument('--bid-price')
     parser.add_argument('--bootstrap-script')
@@ -94,6 +98,7 @@ def create_parser():
     parser.add_argument('--defaults', nargs='*')
     parser.add_argument('--ec2-key')
     parser.add_argument('--ec2-subnet-id')
+    parser.add_argument('--jobflow-role', default=DEFAULT_JOBFLOW_ROLE)
     parser.add_argument('--keep-alive', action='store_true')
     parser.add_argument('--log-level', '-l', type=str.upper, default='INFO')
     parser.add_argument('--name')

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -5,6 +5,7 @@ import logging
 import datetime
 
 from sparksteps import steps
+from sparksteps.defaults import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,21 @@ def parse_conf(raw_conf_list):
     return defaults
 
 
+def parse_apps(raw_app_list):
+    """
+    Given a list of app name strings,
+    returns formatted application configuration value.
+
+    Examples:
+        >>> from pprint import pprint
+        >>> pprint(parse_apps(['hadoop', 'spark']))
+        [{'Name': 'Hadoop', 'Name': 'Spark'}]
+    """
+    return sorted(
+        [{'Name': app_name.capitalize()} for app_name in set(raw_app_list)],
+        key=lambda x: x['Name'])
+
+
 def emr_config(release_label, keep_alive=False, **kw):
     timestamp = datetime.datetime.now().replace(microsecond=0)
     config = dict(
@@ -64,9 +80,9 @@ def emr_config(release_label, keep_alive=False, **kw):
             'KeepJobFlowAliveWhenNoSteps': keep_alive,
             'TerminationProtected': False,
         },
-        Applications=[{'Name': 'Hadoop'}, {'Name': 'Spark'}],
+        Applications=parse_apps(kw.get('app_list', DEFAULT_APP_LIST)),
         VisibleToAllUsers=True,
-        JobFlowRole='EMR_EC2_DefaultRole',
+        JobFlowRole=kw.get('jobflow_role', DEFAULT_JOBFLOW_ROLE),
         ServiceRole='EMR_DefaultRole',
     )
 

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -5,7 +5,9 @@ import logging
 import datetime
 
 from sparksteps import steps
-from sparksteps.defaults import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
+
+DEFAULT_JOBFLOW_ROLE = 'EMR_EC2_DefaultRole'
+DEFAULT_APP_LIST = ['Hadoop', 'Spark']
 
 logger = logging.getLogger(__name__)
 

--- a/sparksteps/defaults.py
+++ b/sparksteps/defaults.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""
+Application CLI defaults
+"""
+DEFAULT_JOBFLOW_ROLE = 'EMR_EC2_DefaultRole'
+DEFAULT_APP_LIST = ['Hadoop', 'Spark']

--- a/sparksteps/defaults.py
+++ b/sparksteps/defaults.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-"""
-Application CLI defaults
-"""
-DEFAULT_JOBFLOW_ROLE = 'EMR_EC2_DefaultRole'
-DEFAULT_APP_LIST = ['Hadoop', 'Spark']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Test Parser."""
+import shlex
+from sparksteps import __main__
+
+
+def test_parser():
+    parser = __main__.create_parser()
+    cmd_args_str = """episodes.py \
+      --jobflow-role MyCustomRole \
+      --s3-bucket my-bucket \
+      --aws-region us-east-1 \
+      --release-label emr-4.7.0 \
+      --uploads examples/dir examples/episodes.avro \
+      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
+      --app-args="--input /home/hadoop/episodes.avro" \
+      --app-list Hadoop Hive Spark \
+      --num-core 1 \
+      --tags Name=MyName CostCenter=MyCostCenter \
+      --defaults spark-defaults key=value another_key=another_value \
+      --maximize-resource-allocation \
+      --debug
+    """
+    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
+    assert args['app'] == 'episodes.py'
+    assert args['jobflow_role'] == 'MyCustomRole'
+    assert args['s3_bucket'] == 'my-bucket'
+    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
+    assert args['app_list'] == ['Hadoop', 'Hive', 'Spark']
+    assert args['debug'] is True
+    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
+    assert args['instance_type_master'] == 'm4.large'
+    assert args['release_label'] == 'emr-4.7.0'
+    assert args['submit_args'] == ['--jars',
+                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
+    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
+    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
+    assert args['maximize_resource_allocation'] is True
+    assert args['num_core'] == 1
+
+
+def test_parser_deprecated_args():
+    parser = __main__.create_parser()
+    cmd_args_str = """episodes.py \
+      --s3-bucket my-bucket \
+      --aws-region us-east-1 \
+      --release-label emr-4.7.0 \
+      --uploads examples/dir examples/episodes.avro \
+      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
+      --app-args="--input /home/hadoop/episodes.avro" \
+      --master m4.4xlarge \
+      --slave c3.8xlarge \
+      --num-core 1 \
+      --dynamic-pricing \
+      --tags Name=MyName CostCenter=MyCostCenter \
+      --defaults spark-defaults key=value another_key=another_value \
+      --maximize-resource-allocation \
+      --debug
+    """
+    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
+    assert args['app'] == 'episodes.py'
+    assert args['s3_bucket'] == 'my-bucket'
+    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
+    assert args['debug'] is True
+    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
+    assert args['instance_type_master'] == 'm4.4xlarge'
+    assert args['instance_type_core'] == 'c3.8xlarge'
+    assert args['dynamic_pricing_task'] is True
+    assert args['release_label'] == 'emr-4.7.0'
+    assert args['submit_args'] == ['--jars',
+                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
+    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
+    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
+    assert args['maximize_resource_allocation'] is True
+
+
+def test_parser_with_bootstrap():
+    parser = __main__.create_parser()
+    cmd_args_str = """episodes.py \
+      --s3-bucket my-bucket \
+      --aws-region us-east-1 \
+      --release-label emr-4.7.0 \
+      --uploads examples/dir examples/episodes.avro \
+      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
+      --app-args="--input /home/hadoop/episodes.avro" \
+      --num-core 1 \
+      --tags Name=MyName CostCenter=MyCostCenter \
+      --defaults spark-defaults key=value another_key=another_value \
+      --bootstrap-script s3://bucket/bootstrap-actions.sh \
+      --debug
+    """
+    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
+    assert args['app'] == 'episodes.py'
+    assert args['s3_bucket'] == 'my-bucket'
+    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
+    assert args['debug'] is True
+    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
+    assert args['instance_type_master'] == 'm4.large'
+    assert args['release_label'] == 'emr-4.7.0'
+    assert args['submit_args'] == ['--jars',
+                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
+    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
+    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
+    assert args['bootstrap_script'] == 's3://bucket/bootstrap-actions.sh'

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -6,7 +6,6 @@ import os.path
 import boto3
 import moto
 
-from sparksteps import __main__
 from sparksteps.cluster import emr_config
 from sparksteps.steps import setup_steps, S3DistCp
 
@@ -24,6 +23,7 @@ EPISODES_AVRO = os.path.join(DATA_DIR, 'episodes.avro')
 def test_emr_cluster_config():
     config = emr_config('emr-5.2.0',
                         instance_type_master='m4.large',
+                        jobflow_role='MyCustomRole',
                         keep_alive=False,
                         instance_type_core='m4.2xlarge',
                         instance_type_task='m4.2xlarge',
@@ -31,7 +31,8 @@ def test_emr_cluster_config():
                         num_task=1,
                         bid_price_task='0.1',
                         maximize_resource_allocation=True,
-                        name="Test SparkSteps")
+                        name="Test SparkSteps",
+                        app_list=['hadoop', 'hive', 'spark'])
     assert config == {'Instances':
                           {'InstanceGroups': [{'InstanceCount': 1,  # NOQA: E127
                                                'InstanceRole': 'MASTER',
@@ -52,9 +53,9 @@ def test_emr_cluster_config():
                            'KeepJobFlowAliveWhenNoSteps': False,
                            'TerminationProtected': False
                            },
-                      'Applications': [{'Name': 'Hadoop'}, {'Name': 'Spark'}],
+                      'Applications': [{'Name': 'Hadoop'}, {'Name': 'Hive'}, {'Name': 'Spark'}],
                       'Name': 'Test SparkSteps',
-                      'JobFlowRole': 'EMR_EC2_DefaultRole',
+                      'JobFlowRole': 'MyCustomRole',
                       'ReleaseLabel': 'emr-5.2.0',
                       'VisibleToAllUsers': True,
                       'ServiceRole': 'EMR_DefaultRole',
@@ -343,99 +344,3 @@ def test_s3_dist_cp_step():
             'Jar': 'command-runner.jar'},
         'Name': 'S3DistCp step'
     }
-
-
-def test_parser():
-    parser = __main__.create_parser()
-    cmd_args_str = """episodes.py \
-      --s3-bucket my-bucket \
-      --aws-region us-east-1 \
-      --release-label emr-4.7.0 \
-      --uploads examples/dir examples/episodes.avro \
-      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
-      --app-args="--input /home/hadoop/episodes.avro" \
-      --num-core 1 \
-      --tags Name=MyName CostCenter=MyCostCenter \
-      --defaults spark-defaults key=value another_key=another_value \
-      --maximize-resource-allocation \
-      --debug
-    """
-    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
-    assert args['app'] == 'episodes.py'
-    assert args['s3_bucket'] == 'my-bucket'
-    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
-    assert args['debug'] is True
-    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
-    assert args['instance_type_master'] == 'm4.large'
-    assert args['release_label'] == 'emr-4.7.0'
-    assert args['submit_args'] == ['--jars',
-                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
-    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
-    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
-    assert args['maximize_resource_allocation'] is True
-    assert args['num_core'] == 1
-
-
-def test_parser_deprecated_args():
-    parser = __main__.create_parser()
-    cmd_args_str = """episodes.py \
-      --s3-bucket my-bucket \
-      --aws-region us-east-1 \
-      --release-label emr-4.7.0 \
-      --uploads examples/dir examples/episodes.avro \
-      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
-      --app-args="--input /home/hadoop/episodes.avro" \
-      --master m4.4xlarge \
-      --slave c3.8xlarge \
-      --num-core 1 \
-      --dynamic-pricing \
-      --tags Name=MyName CostCenter=MyCostCenter \
-      --defaults spark-defaults key=value another_key=another_value \
-      --maximize-resource-allocation \
-      --debug
-    """
-    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
-    assert args['app'] == 'episodes.py'
-    assert args['s3_bucket'] == 'my-bucket'
-    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
-    assert args['debug'] is True
-    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
-    assert args['instance_type_master'] == 'm4.4xlarge'
-    assert args['instance_type_core'] == 'c3.8xlarge'
-    assert args['dynamic_pricing_task'] is True
-    assert args['release_label'] == 'emr-4.7.0'
-    assert args['submit_args'] == ['--jars',
-                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
-    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
-    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
-    assert args['maximize_resource_allocation'] is True
-
-
-def test_parser_with_bootstrap():
-    parser = __main__.create_parser()
-    cmd_args_str = """episodes.py \
-      --s3-bucket my-bucket \
-      --aws-region us-east-1 \
-      --release-label emr-4.7.0 \
-      --uploads examples/dir examples/episodes.avro \
-      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
-      --app-args="--input /home/hadoop/episodes.avro" \
-      --num-core 1 \
-      --tags Name=MyName CostCenter=MyCostCenter \
-      --defaults spark-defaults key=value another_key=another_value \
-      --bootstrap-script s3://bucket/bootstrap-actions.sh \
-      --debug
-    """
-    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
-    assert args['app'] == 'episodes.py'
-    assert args['s3_bucket'] == 'my-bucket'
-    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
-    assert args['debug'] is True
-    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
-    assert args['instance_type_master'] == 'm4.large'
-    assert args['release_label'] == 'emr-4.7.0'
-    assert args['submit_args'] == ['--jars',
-                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
-    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
-    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
-    assert args['bootstrap_script'] == 's3://bucket/bootstrap-actions.sh'


### PR DESCRIPTION
This pull request adds two (backwards-compatible) additional CLI parameters to configure the `jobflow_role` and set of `Applications` installed on the EMR cluster.

The release of this should bump the app to version `v1.1.0`.