### PR TITLE
Raise an error if one of the file or directory paths provided do not exist

### DIFF
--- a/sparksteps/steps.py
+++ b/sparksteps/steps.py
@@ -165,7 +165,7 @@ def upload_steps(s3_resource, bucket, path):
         s3_resource.meta.client.upload_file(path, bucket, copy_step.key)
         steps.append(copy_step)
     else:
-        raise ValueError(
+        raise FileNotFoundError(
             '{} does not exist (does not reference a valid file or path).'
             .format(path))
     return steps

--- a/sparksteps/steps.py
+++ b/sparksteps/steps.py
@@ -160,10 +160,14 @@ def upload_steps(s3_resource, bucket, path):
         copy_step = CopyStep(bucket, basename + '.zip')
         zip_to_s3(s3_resource, path, bucket, key=copy_step.key)
         steps.extend([copy_step, UnzipStep(path)])
-    else:
+    elif os.path.isfile(path):
         copy_step = CopyStep(bucket, basename)
         s3_resource.meta.client.upload_file(path, bucket, copy_step.key)
         steps.append(copy_step)
+    else:
+        raise ValueError(
+            '{} does not exist (does not reference a valid file or path).'
+            .format(path))
     return steps
 
 

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -330,6 +330,24 @@ def test_setup_steps():
          'Name': 'Run episodes.py'}]
 
 
+@moto.mock_s3
+def test_setup_steps_non_existing_upload_file():
+    s3 = boto3.resource('s3', region_name=AWS_REGION_NAME)
+    s3.create_bucket(Bucket=TEST_BUCKET)
+    dne_file_path = os.path.join(DATA_DIR, 'does_not_exist.jar')
+    try:
+        setup_steps(s3,
+                    TEST_BUCKET,
+                    EPISODES_APP,
+                    submit_args="--jars /home/hadoop/dir/test.jar".split(),
+                    app_args="--input /home/hadoop/episodes.avro".split(),
+                    uploads=[dne_file_path])
+    except ValueError as e:
+        assert str(e) == '{} does not exist (does not reference a valid file or path).'.format(dne_file_path)
+        return
+    assert False, 'Expected ValueError to be raised when `--uploads` parameter contains path to non-existing file or directory.'  # NOQA: E501
+
+
 def test_s3_dist_cp_step():
     splitted = shlex.split(
         "--s3Endpoint=s3.amazonaws.com --src=s3://mybucket/logs/j-3GYXXXXXX9IOJ/node/ --dest=hdfs:///output --srcPattern=.*[a-zA-Z,]+")  # NOQA: E501

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -342,7 +342,7 @@ def test_setup_steps_non_existing_upload_file():
                     submit_args="--jars /home/hadoop/dir/test.jar".split(),
                     app_args="--input /home/hadoop/episodes.avro".split(),
                     uploads=[dne_file_path])
-    except ValueError as e:
+    except FileNotFoundError as e:
         assert str(e) == '{} does not exist (does not reference a valid file or path).'.format(dne_file_path)
         return
     assert False, 'Expected ValueError to be raised when `--uploads` parameter contains path to non-existing file or directory.'  # NOQA: E501


### PR DESCRIPTION
Ran into an issue where a path provided to `--uploads` parameter did not exist, but the sparksteps process completed with a zero exit code. This change tightens up the error checking a bit to fail if one of the input paths does not refer to a directory or a file.

Technically, this is a backwards incompatible change, should therefore be released with a new major version.