### PR TITLE
Additional CLI parameter: s3-path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,20 @@ Changelog
 Releases
 --------
 
+v2.0.0 (2019-07-31)
+~~~~~~~~~~~~~~~~~~~
+
+* Add `s3-path` CLI argument to optionally configure the path prefix used when writing sparksteps related assets such as sources (file uploads) and logs.
+
+**NOTE:** This is a backwards incompatible change as `sources/` and `logs/` are now written to the location specified by the `s3-path` argument.
+Prior to this change logs were written to `s3://S3_BUCKET/logs/sparksteps` and uploads to `s3://S3_BUCKET/sparksteps/sources`.
+
+
 v1.1.1 (2019-07-22)
 ~~~~~~~~~~~~~~~~~~~
 
 * Raise an error if one of the file or directory paths provided do not exist
+
 
 v1.1.0 (2019-07-13)
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ CLI Options
       num-task:                     number of task nodes
       release-label:                EMR release label
       s3-bucket:                    name of s3 bucket to upload spark file (required)
+      s3-path:                      path within s3-bucket to use when writing assets (optional)
       s3-dist-cp:                   s3-dist-cp step after spark job is done
       submit-args:                  arguments passed to spark-submit
       tags:                         EMR cluster tags of the form "key1=value1 key2=value2"

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ CLI Options
       num-task:                     number of task nodes
       release-label:                EMR release label
       s3-bucket:                    name of s3 bucket to upload spark file (required)
-      s3-path:                      path within s3-bucket to use when writing assets (optional)
+      s3-path:                      path within s3-bucket to use when writing assets
       s3-dist-cp:                   s3-dist-cp step after spark job is done
       submit-args:                  arguments passed to spark-submit
       tags:                         EMR cluster tags of the form "key1=value1 key2=value2"

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -38,7 +38,7 @@ Prompt parameters:
   num-task:                     number of task nodes
   release-label:                EMR release label
   s3-bucket:                    name of s3 bucket to upload spark file (required)
-  s3-path:                      path (key prefix) within s3-bucket to use when uploading spark file (optional)
+  s3-path:                      path (key prefix) within s3-bucket to use when uploading spark file
   s3-dist-cp:                   s3-dist-cp step after spark job is done
   submit-args:                  arguments passed to spark-submit
   tags:                         EMR cluster tags of the form "key1=value1 key2=value2"
@@ -142,7 +142,7 @@ def parse_cli_args(parser, args=None):
     # Perform sanitization on any arguments
     if args['s3_path'] and args['s3_path'].startswith('/'):
         raise ValueError(
-            'Provided value for s3-path "{S3_PATH}" cannot have leading "/" character.'.format(args.s3_path))
+            'Provided value for s3-path "{S3_PATH}" cannot have leading "/" character.'.format(args['s3_path']))
 
     return args
 

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -60,7 +60,6 @@ Examples:
 from __future__ import print_function
 
 import json
-import os
 import shlex
 import logging
 import argparse
@@ -74,12 +73,6 @@ from sparksteps.cluster import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
 
 logger = logging.getLogger(__name__)
 LOGFORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-
-
-def is_valid_file(parser, arg):
-    if not os.path.exists(arg):
-        parser.error("The file %s does not exist!" % arg)
-    return arg
 
 
 def create_parser():
@@ -142,52 +135,11 @@ def create_parser():
 
 def parse_cli_args(parser, args=None):
     """
-    Utilizes `parser` to parse command line variables and logs
-     warnings for deprecated arguments.
+    Utilizes `parser` to parse command line variables and logs.
     """
-    def warn_deprecated_arg(argument, replacement):
-        logger.warning(
-            "Argument '--%s' has been deprecated in favor of '--%s'. "
-            "Support for '--%s' will be removed entirely in a future version.",
-            argument, replacement, argument)
-
-    def warn_deprecated_arg_overrides(argument, replacement):
-        logger.warning(
-            "Both deprecated argument '--%s' has been defined and replacement"
-            " argument '--%s'. Using '--%s'.",
-            argument, replacement, replacement)
-
-    def warn_and_override(args, argument, overrides, force_override=False):
-        if args.get(argument):
-            args = args.copy()
-            for replacement in overrides:
-                warn_deprecated_arg(argument, replacement.replace('_', '-'))
-                if not args.get(replacement) or force_override:
-                    args[replacement] = args.get(argument)
-                else:
-                    warn_deprecated_arg_overrides(argument, replacement)
-            del args[argument]
-        return args
-
     args = vars(parser.parse_args(args))
 
-    # Check whether any deprecated arguments were used,
-    # and throw a warning if this was the case.
-
-    # Alias 'master' -> 'instance-type-master'.
-    # 'master' always overrides 'instance-type-master' in order to guarantee backwards compatibility.
-    args = warn_and_override(args, 'master', ['instance_type_master'], force_override=True)
-    # Alias 'slave' -> 'instance-type-core', 'instance-type-task'.
-    # '--slave' has been replaced by two arguments:
-    #   '--instance-type-core': used to specify the instance type of core nodes.
-    #   '--instance-type-task': used to specify the instance type of task nodes.
-    # The newer version requires the caller to be more explicit about what
-    # instances should be used.
-    args = warn_and_override(args, 'slave', ['instance_type_core', 'instance_type_task'])
-    # Alias 'dynamic-pricing' -> 'dynamic-pricing-task'.
-    args = warn_and_override(args, 'dynamic_pricing', ['dynamic_pricing_task'])
-
-    # Perform sanitization on any CLI arguments
+    # Perform sanitization on any arguments
     if args['s3_path'] and args['s3_path'].startswith('/'):
         raise ValueError(
             'Provided value for s3-path "{S3_PATH}" cannot have leading "/" character.'.format(args.s3_path))

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Create EMR cluster."""
+import os
 import getpass
 import logging
 import datetime
@@ -135,7 +136,7 @@ def emr_config(release_label, keep_alive=False, **kw):
     if kw.get('ec2_subnet_id'):
         config['Instances']['Ec2SubnetId'] = kw['ec2_subnet_id']
     if kw.get('debug', False) and kw.get('s3_bucket'):
-        config['LogUri'] = 's3://%s/logs/sparksteps/' % kw['s3_bucket']
+        config['LogUri'] = os.path.join('s3://', kw['s3_bucket'], kw['s3_path'], 'logs/')
         config['Steps'] = [steps.DebugStep().step]
     if kw.get('tags'):
         config['Tags'] = parse_tags(kw['tags'])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,41 +39,6 @@ def test_parser():
     assert args['num_core'] == 1
 
 
-def test_parser_deprecated_args():
-    parser = __main__.create_parser()
-    cmd_args_str = """episodes.py \
-      --s3-bucket my-bucket \
-      --aws-region us-east-1 \
-      --release-label emr-4.7.0 \
-      --uploads examples/dir examples/episodes.avro \
-      --submit-args="--jars /home/hadoop/lib/spark-avro_2.10-2.0.2.jar" \
-      --app-args="--input /home/hadoop/episodes.avro" \
-      --master m4.4xlarge \
-      --slave c3.8xlarge \
-      --num-core 1 \
-      --dynamic-pricing \
-      --tags Name=MyName CostCenter=MyCostCenter \
-      --defaults spark-defaults key=value another_key=another_value \
-      --maximize-resource-allocation \
-      --debug
-    """
-    args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
-    assert args['app'] == 'episodes.py'
-    assert args['s3_bucket'] == 'my-bucket'
-    assert args['app_args'] == ['--input', '/home/hadoop/episodes.avro']
-    assert args['debug'] is True
-    assert args['defaults'] == ['spark-defaults', 'key=value', 'another_key=another_value']
-    assert args['instance_type_master'] == 'm4.4xlarge'
-    assert args['instance_type_core'] == 'c3.8xlarge'
-    assert args['dynamic_pricing_task'] is True
-    assert args['release_label'] == 'emr-4.7.0'
-    assert args['submit_args'] == ['--jars',
-                                   '/home/hadoop/lib/spark-avro_2.10-2.0.2.jar']
-    assert args['uploads'] == ['examples/dir', 'examples/episodes.avro']
-    assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
-    assert args['maximize_resource_allocation'] is True
-
-
 def test_parser_with_bootstrap():
     parser = __main__.create_parser()
     cmd_args_str = """episodes.py \


### PR DESCRIPTION
Backwards incompatible change (major release) to support additional `s3-path` CLI argument to support writing to a custom path prefix within s3-bucket. This is the path prefix sparksteps will use when writing anything to the bucket (logs and sources).

Before this change, the application wrote sources to a subdirectory `/sparksteps/sources` under the provided bucket. After this change, the application can optionally write sources to `/custom/path/sources` if provided `custom/path` as the value of `s3-path`.

