### PR TITLE
Adding feature to make sparksteps synchronous (--wait)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Changelog
 Releases
 --------
 
+v2.1.0 (2019-08-27)
+~~~~~~~~~~~~~~~~~~~
+
+* Add `wait` CLI option. When `--wait` is passed, waits for EMR cluster steps to complete before application exits, 
+sleeping 150 seconds (default) between each poll attempt. An optional integer value can be passed to specify the polling
+interval to use, in seconds.
+
+
 v2.0.0 (2019-07-31)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ CLI Options
       submit-args:                  arguments passed to spark-submit
       tags:                         EMR cluster tags of the form "key1=value1 key2=value2"
       uploads:                      files to upload to /home/hadoop/ in master instance
+      wait:                         poll until all steps are complete (or error)
 
 Example
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dateutil==2.8.0
 s3transfer==0.2.1
 six==1.12.0
 urllib3==1.25.3
+polling==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     keywords='aws emr pyspark spark boto'.split(),
     license='Apache License 2.0',
     install_requires=[
-        'boto3>=1.3.1'
+        'boto3>=1.3.1',
+        'polling==0.3.0'
     ],
     setup_requires=[
         'pytest-runner',

--- a/sparksteps/poll.py
+++ b/sparksteps/poll.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for polling for cluster status to determine if it's in a terminal state.
+"""
+import logging
+from polling import poll
+
+
+logger = logging.getLogger(__name__)
+
+NON_TERMINAL_STATES = frozenset(['PENDING', 'RUNNING', 'CONTINUE', 'CANCEL_PENDING'])
+FAILED_STATE = frozenset(['CANCELLED', 'FAILED', 'INTERRUPTED'])
+
+
+def failure_message_from_response(response):
+    """
+    Given EMR response, returns a descriptive error message
+    """
+    fail_details = response['Step']['Status'].get('FailureDetails')
+    if fail_details:
+        return 'for reason {} with message {} and log file {}'\
+            .format(
+                fail_details.get('Reason'),
+                fail_details.get('Message'),
+                fail_details.get('LogFile')
+            )
+
+
+def is_step_complete(emr_client, jobflow_id, step_id):
+    """
+    Will query EMR for step status, returns True if complete, False otherwise
+    """
+    response = emr_client.describe_step(ClusterId=jobflow_id, StepId=step_id)
+
+    if not response['ResponseMetadata']['HTTPStatusCode'] == 200:
+        logger.info('Bad HTTP response: %s', response)
+        return False
+
+    state = response['Step']['Status']['State']
+    logger.info('Job flow currently %s', state)
+
+    if state in NON_TERMINAL_STATES:
+        return False
+
+    if state in FAILED_STATE:
+        final_message = 'EMR job failed'
+        failure_message = failure_message_from_response(response)
+        if failure_message:
+            final_message += ' ' + failure_message
+        raise Exception(final_message)
+
+    return True
+
+
+def wait_for_step_complete(emr_client, jobflow_id, step_id, sleep_interval_s):
+    """
+    Will poll EMR until provided step has a terminal status
+    """
+    poll(
+        is_step_complete,
+        args=(emr_client, jobflow_id, step_id),
+        step=sleep_interval_s,
+        poll_forever=True
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,7 +19,8 @@ def test_parser():
       --tags Name=MyName CostCenter=MyCostCenter \
       --defaults spark-defaults key=value another_key=another_value \
       --maximize-resource-allocation \
-      --debug
+      --debug \
+      --wait
     """
     args = __main__.parse_cli_args(parser, args=shlex.split(cmd_args_str))
     assert args['app'] == 'episodes.py'
@@ -37,6 +38,7 @@ def test_parser():
     assert args['tags'] == ['Name=MyName', 'CostCenter=MyCostCenter']
     assert args['maximize_resource_allocation'] is True
     assert args['num_core'] == 1
+    assert args['wait'] == 150
 
 
 def test_parser_with_bootstrap():

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Test Poll logic."""
+import os
+import pytest
+import boto3
+
+from unittest.mock import MagicMock, patch
+
+from moto import mock_emr, mock_s3
+from moto.emr.models import emr_backends
+
+from sparksteps.cluster import emr_config
+from sparksteps.poll import failure_message_from_response, is_step_complete, wait_for_step_complete
+
+
+@pytest.fixture(scope='function')
+def aws_credentials():
+    """
+    Mocked AWS Credentials for moto to prevent impact to real infrastructure
+    """
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+
+
+@pytest.fixture(scope='function')
+def emr_client(aws_credentials):
+    with mock_emr():
+        yield boto3.client('emr', region_name='us-east-1')
+
+
+@pytest.fixture(scope='function')
+def s3_client(aws_credentials):
+    with mock_s3():
+        yield boto3.client('s3', region_name='us-east-1')
+
+
+def test_failure_message_from_response():
+    """
+    Ensure failure_message_from_response returns expected string
+    """
+    mock_aws_response = {
+        'Step': {
+            'Status': {
+                'FailureDetails': {
+                    'Reason': 'error-reason',
+                    'Message': 'error-message',
+                    'LogFile': '/path/to/logfile'
+                }
+            }
+        }
+    }
+    expected = 'for reason error-reason with message error-message and log file /path/to/logfile'
+    actual = failure_message_from_response(mock_aws_response)
+    assert expected == actual, 'Mismatch, Expected: {}, Actual: {}'.format(expected, actual)
+
+    del mock_aws_response['Step']['Status']['FailureDetails']
+    assert failure_message_from_response(mock_aws_response) is None, \
+        'Expected None when FailureDetails key is missing from response.'
+
+
+def set_step_state(step_id, cluster_id, new_state):
+    """
+    Helper to update the state of a step
+    """
+    for step in emr_backends['us-east-1'].clusters[cluster_id].steps:
+        if step.id == step_id:
+            step.state = new_state
+
+
+def test_is_step_complete(emr_client, s3_client):
+    """
+    Ensure is_step_complete returns expected boolean value
+    """
+    cluster_config = emr_config(
+        'emr-5.2.0',
+        instance_type_master='m4.large',
+        jobflow_role='MyCustomRole',
+        keep_alive=False,
+        instance_type_core='m4.2xlarge',
+        instance_type_task='m4.2xlarge',
+        num_core=1,
+        num_task=1,
+        bid_price_task='0.1',
+        maximize_resource_allocation=True,
+        name='Test SparkSteps',
+        app_list=['hadoop', 'hive', 'spark']
+    )
+    response = emr_client.run_job_flow(**cluster_config)
+    cluster_id = response['JobFlowId']
+
+    test_step = {
+        'Name': 'test-step',
+        'ActionOnFailure': 'CANCEL_AND_WAIT',
+        'HadoopJarStep': {
+            'Jar': 'command-runner.jar',
+            'Args': ['state-pusher-script']
+        }
+    }
+    response = emr_client.add_job_flow_steps(JobFlowId=cluster_id, Steps=[test_step])
+    last_step_id = response['StepIds'][-1]
+
+    # while the step state is non-terminal is_step_complete should return False
+    for state in ['PENDING', 'RUNNING', 'CONTINUE', 'CANCEL_PENDING']:
+        set_step_state(last_step_id, cluster_id, state)
+        assert not is_step_complete(emr_client, cluster_id, last_step_id), \
+            'Expected last step to not be complete when step state is {}'.format(state)
+
+    # when last step is in a terminal state (completed), is_step_complete should return True
+    set_step_state(last_step_id, cluster_id, 'COMPLETED')
+    assert is_step_complete(emr_client, cluster_id, last_step_id), \
+        'Expected last step to be complete when last step state is {}'.format('COMPLETED')
+
+    # when last step is in a failed state, is_step_complete should raise a helpful exception
+    for state in ['CANCELLED', 'FAILED', 'INTERRUPTED']:
+        set_step_state(last_step_id, cluster_id, state)
+        try:
+            is_step_complete(emr_client, cluster_id, last_step_id)
+            assert False, \
+                'Expected an exception to be raised when the last step is in {} state'.format(state)
+        except Exception as e:
+            assert 'EMR job failed' == str(e), 'Exception message not as expected'
+
+
+def test_wait_for_step_complete():
+    """
+    Ensure polling.poll is called with expected arguments
+    """
+    with patch('sparksteps.poll.poll') as mock_poll:
+        mock_emr = MagicMock()
+        jobflow_id = 'fake-jobflow-id'
+        step_id = 'fake-step-id'
+        wait_for_step_complete(mock_emr, jobflow_id, step_id, 1)
+        mock_poll.assert_called_once_with(
+            is_step_complete, args=(mock_emr, jobflow_id, step_id), step=1, poll_forever=True)


### PR DESCRIPTION
Addresses https://github.com/jwplayer/sparksteps/issues/25

Make sparksteps synchronous by adding `--wait` ~~and `--wait-sleep`~~ CLI options. This has some nice utility for users of Airflow as it can enable more elegant retry logic. Currently, if we have a step which runs sparksteps and a subsequent task in the airflow DAG manages polling, we lose the ability to retry the sparksteps call.

Now, with `--wait` added to a sparksteps call, the process will wait (polling every 150s by default ~~but configurable via the `--wait-sleep` CLI option~~) until the last step on the EMR cluster completes or terminates with errors.

Example output:
```
...
2019-08-26 18:07:42,452 sparksteps.__main__ INFO     Launching cluster...
2019-08-26 18:07:42,918 sparksteps.__main__ INFO     Cluster ID: j-1FKQCCZA0T05X
2019-08-26 18:07:43,398 sparksteps.__main__ INFO     Step IDs: ["s-26RB8N1R5WXQV", "s-1N5P37PLBG9NE", "s-1PY4RSOPUBBI7", "s-3ADBAMRCBNO17"]
2019-08-26 18:07:43,398 sparksteps.__main__ INFO     Waiting until step s-3ADBAMRCBNO17 is complete...
2019-08-26 18:07:43,442 sparksteps.poll INFO     Job flow currently PENDING
2019-08-26 18:10:13,626 sparksteps.poll INFO     Job flow currently PENDING
2019-08-26 18:12:43,800 sparksteps.poll INFO     Job flow currently PENDING
2019-08-26 18:15:13,983 sparksteps.poll INFO     Job flow currently RUNNING
2019-08-26 18:17:44,171 sparksteps.poll INFO     Job flow currently COMPLETED
```

This is backwards-compatible: should be released with version `v2.1.0`.

Also, updated the `sparksteps` logger to use the same log level as main's logger was before. I noticed that without this, I wasn't able to see log lines printed by the `poll.py` file as it wasn't inheriting this configuration.

A dependency is introduced to @justiniso 's polling library to handle periodic polling logic.

Much of the logic was inspired by Airflow's `EmrStepSensor`.

Manually tested with both `--keep-alive` and without and worked in both cases.