### PR TITLE
Support S3 paths in uploads CLI option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 Releases
 --------
 
+v2.2.0 (2019-09-19)
+~~~~~~~~~~~~~~~~~~~
+
+* Support S3 paths in the `uploads` CLI option. A copy step will be added to the EMR cluster which will copy into /home/hadoop from the provided remote path.
+
+
 v2.1.0 (2019-08-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/sparksteps/steps.py
+++ b/sparksteps/steps.py
@@ -31,7 +31,7 @@ def zip_to_s3(s3_resource, dirpath, bucket, key):
 
 
 def parse_s3_path(s3_path):
-    """Returns bucket, path, and filename of an S3 path"""
+    """Return bucket, path, and filename of an S3 path"""
     parsed = urlparse(s3_path, allow_fragments=False)
     bucket = parsed.netloc
     path, filename = parsed.path.rsplit('/', 1)

--- a/sparksteps/steps.py
+++ b/sparksteps/steps.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import zipfile
+from urllib.parse import urlparse
 
 REMOTE_DIR = '/home/hadoop/'
 
@@ -27,6 +28,15 @@ def zip_to_s3(s3_resource, dirpath, bucket, key):
         tmp.seek(0)  # Reset file pointer
         response = s3_resource.Bucket(bucket).put_object(Key=key, Body=tmp)
     return response
+
+
+def parse_s3_path(s3_path):
+    """Returns bucket, path, and filename of an S3 path"""
+    parsed = urlparse(s3_path, allow_fragments=False)
+    bucket = parsed.netloc
+    path, filename = parsed.path.rsplit('/', 1)
+    path = path[1:] if path.startswith('/') else path
+    return bucket, path, filename
 
 
 class CmdStep(object):
@@ -68,7 +78,7 @@ class CopyStep(CmdStep):
 
     @property
     def key(self):
-        return os.path.join(self.path, 'sources/', self.filename)
+        return os.path.join(self.path, self.filename)
 
     @property
     def s3_uri(self):
@@ -155,13 +165,19 @@ def upload_steps(s3_resource, bucket, bucket_path, src_path):
     """Upload files to S3 and get steps."""
     steps = []
     basename = get_basename(src_path)
-    if os.path.isdir(src_path):  # zip directory
-        copy_step = CopyStep(bucket, bucket_path, basename + '.zip')
-        zip_to_s3(s3_resource, src_path, bucket, key=copy_step.key)
+    default_dest_path = os.path.join(bucket_path, 'sources')
+    if src_path.startswith('s3://'):
+        steps.append(CopyStep(*parse_s3_path(src_path)))
+    elif os.path.isdir(src_path):  # Zip directory
+        basename = basename + '.zip'
+        dest_path = os.path.join(default_dest_path, basename)
+        zip_to_s3(s3_resource, src_path, bucket, key=dest_path)
+        copy_step = CopyStep(bucket, default_dest_path, basename)
         steps.extend([copy_step, UnzipStep(src_path)])
     elif os.path.isfile(src_path):
-        copy_step = CopyStep(bucket, bucket_path, basename)
-        s3_resource.meta.client.upload_file(src_path, bucket, copy_step.key)
+        dest_path = os.path.join(default_dest_path, basename)
+        s3_resource.meta.client.upload_file(src_path, bucket, dest_path)
+        copy_step = CopyStep(bucket, default_dest_path, basename)
         steps.append(copy_step)
     else:
         raise FileNotFoundError(

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -361,7 +361,7 @@ def test_setup_steps_with_bucket_path():
                          EPISODES_APP,
                          submit_args="--jars /home/hadoop/dir/test.jar".split(),
                          app_args="--input /home/hadoop/episodes.avro".split(),
-                         uploads=[LIB_DIR, EPISODES_AVRO])
+                         uploads=[LIB_DIR, EPISODES_AVRO, 's3://custom-bucket/custom/path/s3_file.py'])
              )
     assert steps == [
         {'HadoopJarStep': {'Jar': 'command-runner.jar',
@@ -381,6 +381,11 @@ def test_setup_steps_with_bucket_path():
                                     '/home/hadoop/']},
          'ActionOnFailure': 'CANCEL_AND_WAIT',
          'Name': 'Copy episodes.avro'},
+        {'HadoopJarStep': {'Jar': 'command-runner.jar',
+                           'Args': ['aws', 's3', 'cp',
+                                    's3://custom-bucket/custom/path/s3_file.py',
+                                    '/home/hadoop/']},
+         'ActionOnFailure': 'CANCEL_AND_WAIT', 'Name': 'Copy s3_file.py'},
         {'HadoopJarStep': {'Jar': 'command-runner.jar',
                            'Args': ['aws', 's3', 'cp',
                                     's3://sparksteps-test/custom/path/prefix/sources/episodes.py',


### PR DESCRIPTION
Addresses: https://github.com/jwplayer/sparksteps/issues/27

A use case which recently came up is distributing files to the master node which already exist on S3. To get around this, we download the remote files locally then pass the local paths to sparksteps. This is not very efficient.

This PR introduces the ability to use S3 paths in the uploads CLI option to get around this. The remote file can be referenced without downloading locally first. The process invoking sparksteps needs to have available AWS credentials which have permission to read the S3 object.

Note: I'm using `urllib.parse` which is only available in python3+.

This is backwards compatible and can be released as version `2.2.0`.