### PR TITLE
Add option to configure service role

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 Releases
 --------
 
+v2.2.0 (2019-09-XX)
+~~~~~~~~~~~~~~~~~~~
+
+* Add option `--service-role` to configure EMR service role beyond the default `EMR_DefaultRole`.
+
+
 v2.1.0 (2019-08-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ CLI Options
       ec2-subnet-id:                Amazon VPC subnet id
       help (-h):                    argparse help
       jobflow-role:                 Amazon EC2 instance profile name to use (Default: EMR_EC2_DefaultRole)
+      service-role:                 AWS IAM service role to use for EMR (Default: EMR_DefaultRole)
       keep-alive:                   whether to keep the EMR cluster alive when there are no steps
       log-level (-l):               logging level (default=INFO)
       instance-type-master:         instance type of of master host (default='m4.large')

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -27,6 +27,7 @@ Prompt parameters:
   ec2-subnet-id:                Amazon VPC subnet id
   help (-h):                    argparse help
   jobflow-role:                 Amazon EC2 instance profile name to use (Default: EMR_EC2_DefaultRole)
+  service-role:                 AWS IAM service role to use for EMR (Default: EMR_DefaultRole)
   keep-alive:                   whether to keep the EMR cluster alive when there are no steps
   log-level (-l):               logging level (default=INFO)
   instance-type-master:         instance type of of master host (default='m4.large')
@@ -70,7 +71,7 @@ import boto3
 from sparksteps import steps
 from sparksteps import cluster
 from sparksteps import pricing
-from sparksteps.cluster import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE
+from sparksteps.cluster import DEFAULT_APP_LIST, DEFAULT_JOBFLOW_ROLE, DEFAULT_SERVICE_ROLE
 from sparksteps.poll import wait_for_step_complete
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,7 @@ def create_parser():
     parser.add_argument('--ec2-key')
     parser.add_argument('--ec2-subnet-id')
     parser.add_argument('--jobflow-role', default=DEFAULT_JOBFLOW_ROLE)
+    parser.add_argument('--service-role', default=DEFAULT_SERVICE_ROLE)
     parser.add_argument('--keep-alive', action='store_true')
     parser.add_argument('--log-level', '-l', type=str.upper, default='INFO')
     parser.add_argument('--name')

--- a/sparksteps/cluster.py
+++ b/sparksteps/cluster.py
@@ -8,6 +8,7 @@ import datetime
 from sparksteps import steps
 
 DEFAULT_JOBFLOW_ROLE = 'EMR_EC2_DefaultRole'
+DEFAULT_SERVICE_ROLE = 'EMR_DefaultRole'
 DEFAULT_APP_LIST = ['Hadoop', 'Spark']
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ def emr_config(release_label, keep_alive=False, **kw):
         Applications=parse_apps(kw.get('app_list', DEFAULT_APP_LIST)),
         VisibleToAllUsers=True,
         JobFlowRole=kw.get('jobflow_role', DEFAULT_JOBFLOW_ROLE),
-        ServiceRole='EMR_DefaultRole',
+        ServiceRole=kw.get('service_role', DEFAULT_SERVICE_ROLE)
     )
 
     for instance_group in ('master', 'core', 'task'):

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -25,6 +25,7 @@ def test_emr_cluster_config():
     config = emr_config('emr-5.2.0',
                         instance_type_master='m4.large',
                         jobflow_role='MyCustomRole',
+                        service_role='MyServiceRole',
                         keep_alive=False,
                         instance_type_core='m4.2xlarge',
                         instance_type_task='m4.2xlarge',
@@ -57,9 +58,9 @@ def test_emr_cluster_config():
                       'Applications': [{'Name': 'Hadoop'}, {'Name': 'Hive'}, {'Name': 'Spark'}],
                       'Name': 'Test SparkSteps',
                       'JobFlowRole': 'MyCustomRole',
+                      'ServiceRole': 'MyServiceRole',
                       'ReleaseLabel': 'emr-5.2.0',
                       'VisibleToAllUsers': True,
-                      'ServiceRole': 'EMR_DefaultRole',
                       'Configurations': [{'Classification': 'spark',
                                           'Properties': {'maximizeResourceAllocation': 'true'}}]
                       }


### PR DESCRIPTION
Address https://github.com/jwplayer/sparksteps/issues/29.

This PR adds a `--service-role` option to configure the EMR role used beyond just the default.