### PR TITLE
Fix get_demand_price returning 0.00

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 Releases
 --------
 
+v2.2.1 (2019-11-04)
+~~~~~~~~~~~~~~~~~~~
+
+* Fix `get_demand_price` returning 0.00 for various instance types.
+
+
 v2.2.0 (2019-09-19)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/sparksteps/pricing.py
+++ b/sparksteps/pricing.py
@@ -21,13 +21,16 @@ EC2_PRICE_FILTER_TEMPLATE = '''
     {{"Field": "preInstalledSw", "Value": "NA", "Type": "TERM_MATCH"}},
     {{"Field": "instanceType", "Value": "{instance_type}", "Type": "TERM_MATCH"}},
     {{"Field": "location", "Value": "{region}", "Type": "TERM_MATCH"}},
-    {{"Field": "licenseModel", "Value": "No License required", "Type": "TERM_MATCH"}}
+    {{"Field": "licenseModel", "Value": "No License required", "Type": "TERM_MATCH"}},
+    {{"Field": "usagetype", "Value": "BoxUsage:{instance_type}", "Type": "TERM_MATCH"}}
 ]
 '''
 
 
 def get_demand_price(pricing_client, instance_type, region='US East (N. Virginia)', operating_system='Linux'):
-    """Retrieves the on-demand price for a particular EC2 instance type in the specified region.
+    """
+    Retrieves the on-demand price for a particular EC2 instance type in the specified region.
+    This function does not take reserved instance pricing into account.
 
     Args:
         pricing_client: Boto3 Pricing client.


### PR DESCRIPTION
For some instance types (e.g. `c5d.9xlarge`), `get_demand_price` would return 0.00 as on-demand instance price, because this is the default 'onDemandPrice' for reserved instance type related SKU's. By filtering on 'usagetype', these SKU's are filtered out from the response returned by get_products.
