### PR TITLE
Correct documentation incorrectly referring to the bootstrap-script arg as bootstrap-action

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ CLI Options
       app-list:                     Space delimited list of applications to be installed on the EMR cluster (Default: Hadoop Spark)
       aws-region:                   AWS region name
       bid-price:                    specify bid price for task nodes
-      bootstrap-action:             include a bootstrap script (s3 path)
+      bootstrap-script:             include a bootstrap script (s3 path)
       cluster-id:                   job flow id of existing cluster to submit to
       debug:                        allow debugging of cluster
       defaults:                     cluster configurations of the form "<classification1> key1=val1 key2=val2 ..."

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -8,7 +8,7 @@ Prompt parameters:
   app-list:                     Applications to be installed on the EMR cluster (Default: Hadoop Spark)
   aws-region:                   AWS region name
   bid-price:                    specify bid price for task nodes
-  bootstrap-action:             include a bootstrap script (s3 path)
+  bootstrap-script:             include a bootstrap script (s3 path)
   cluster-id:                   job flow id of existing cluster to submit to
   debug:                        allow debugging of cluster
   defaults:                     cluster configurations of the form "<classification1> key1=val1 key2=val2 ..."


### PR DESCRIPTION
**What will this Pull Request do?**

Updates the readme and main file to correctly refer to the `bootstrap-script` arg correctly. 

**Why is this Pull Request needed?**

The two files changed currently refer to the arg as `bootstrap-action`

**What's the one goal of this PR? (cleaning/refactoring/feature/bugfix/experiment)**

cleaning/bugfix


