### PR TITLE
Fix spot pricing bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: python
 dist: xenial
 python:
-- "3.5"
 - "3.6"
 - "3.7"
+- "3.8"
 install: pip install tox-travis
 script: tox
 cache:
@@ -21,6 +21,6 @@ deploy:
   password:
     secure: efbMWAjS3IcYEjqE456Uh+UhFWXFRN/y0xAJCLBC8MdpVq/5uAPmRzz551FCn4c94Ww5q3vnrRan9Jq1g/gpWVWzYmaCIdjta3RkH8MNIbIXjGUw5N4r8xt+XX+46f/fcOoRkQXW19QnyCSxbhzQ6HQc212W2pU40UDSxpESLtlHr18fo21gLqGxvfF1v50reEuewsnhQaG6iITdbpHkhxjpekn59B/uk3rCM6Q5ehQRqqCyMZx+P226GyDhYitIPklyJsoG/L0TZFkdtN51sKR+GyIjGsZIphDrSyBoFqWwazB98As62HN41PFsOZdbTakBIamgafOtmJ+gdghlf++W+Q20IFTs5XffUs9uoyUU4xiTqYjDPjwLbSF01n5oI67RP94PQW5AW7NZREfyBjP5cRmY2k1iDOe4QElehftpudnZbypIZa+ah0fzCvv/2FfkQpvxuCiruKZscou1thljMNz5K9ipOb0fCBYY6DRMnSfA4Y1OojiAwe8vYk/uqWnmpudzaWy2Q/VntiM+EqSdOwH4PMSM9gm3WhMK8LwtvUi8gpUfynJksSiuh/kfG93VYv1N0t/8vVn2rdrwdsPKmA7lZzkuGU27/rHa9BLpe5uNGDOald8q2jvpgJLSb7/DkTmy2JR5ZwEMEVRDbGtpbkiGuyQ/yO3C46/uGjY=
   on:
-    python: "3.5"
+    python: "3.6"
     tags: true
     repo: jwplayer/sparksteps

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Releases
 --------
 
-v2.2.2 (2020-08-20)
+v3.0.0 (2020-08-20)
 ~~~~~~~~~~~~~~~~~~~
 
 * Fix `determine_best_price` returning a spot price that would be below the current spot price in some conditions.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Changelog
 Releases
 --------
 
+v2.2.2 (2020-08-20)
+~~~~~~~~~~~~~~~~~~~
+
+* Fix `determine_best_price` returning a spot price that would be below the current spot price in some conditions.
+* Dropped support for Python 3.5.
+
+
 v2.2.1 (2019-11-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -100,14 +100,14 @@ Run Spark Job on Existing Cluster
 You can use the option ``--cluster-id`` to specify a cluster to upload
 and run the Spark job. This is especially helpful for debugging.
 
-Dynamic Pricing (alpha)
+Dynamic Pricing
 -----------------------
 
 Use CLI option ``--dynamic-pricing-<instance-type>`` to allow sparksteps to dynamically
 determine the best bid price for EMR instances within a certain instance group.
 
 Currently the algorithm looks back at spot history over the last 12
-hours and calculates ``min(50% * on_demand_price, max_spot_price)`` to
+hours and calculates ``min(0.8 * on_demand_price, 1.2 * max_spot_price)`` to
 determine bid price. That said, if the current spot price is over 80% of
 the on-demand cost, then on-demand instances are used to be
 conservative.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-boto3==1.9.182
-botocore==1.12.182
-docutils==0.14
-jmespath==0.9.4
-python-dateutil==2.8.0
-s3transfer==0.2.1
-six==1.12.0
-urllib3==1.25.3
+boto3==1.14.46
+botocore==1.17.46
+docutils==0.15.2
+jmespath==0.10.0
 polling==0.3.0
+python-dateutil==2.8.1
+s3transfer==0.3.3
+six==1.15.0
+urllib3==1.25.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ test=pytest
 
 [tool:pytest]
 addopts=-vv --flake8 -m 'not integration'
+markers=
+    integration
 
 [flake8]
 max-line-length=120

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
         Intended Audience :: Developers
         License :: OSI Approved :: Apache Software License
         Environment :: Console
-        Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         """).strip().splitlines(),
+    python_requires='>=3.6'
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'pytest',
         'pytest-flake8',
         'moto',
-        'google-compute-engine'
+        'ecdsa<0.15'
     ],
     include_package_data=True,
     zip_safe=False,
@@ -48,5 +48,6 @@ setup(
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
         """).strip().splitlines(),
 )

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -150,7 +150,7 @@ def parse_cli_args(parser, args=None):
     # Perform sanitization on any arguments
     if args['s3_path'] and args['s3_path'].startswith('/'):
         raise ValueError(
-            'Provided value for s3-path "{S3_PATH}" cannot have leading "/" character.'.format(args['s3_path']))
+            f"Provided value for s3-path \"{args['s3_path']}\" cannot have leading \"/\" character.")
 
     if args['wait'] is None:
         args['wait'] = DEFAULT_SLEEP_INTERVAL_SECONDS

--- a/sparksteps/pricing.py
+++ b/sparksteps/pricing.py
@@ -106,7 +106,9 @@ def determine_best_price(demand_price, aws_zone):
     """
     if aws_zone.current >= demand_price * SPOT_DEMAND_THRESHOLD_FACTOR:
         return demand_price, False
-    return min(2 * aws_zone.max, demand_price * 0.5), True
+    # We always bid higher than the maximum current spot price for a particular instance type
+    # in order to make it less likely that our clusters will be shutdown.
+    return min(1.2 * aws_zone.max, demand_price * SPOT_DEMAND_THRESHOLD_FACTOR), True
 
 
 def get_bid_price(ec2_client, pricing_client, instance_type):

--- a/tests/test_sparksteps.py
+++ b/tests/test_sparksteps.py
@@ -128,46 +128,48 @@ def test_emr_cluster_config_with_defaults():
                         defaults=['spark-defaults', 'spark.speculation=false',
                                   'yarn-site', 'yarn.nodemanager.vmem-check-enabled=true'])
     print(config['Configurations'])
-    assert config == {'Instances':
-                          {'InstanceGroups': [{'InstanceCount': 1,  # NOQA: E127
-                                               'InstanceRole': 'MASTER',
-                                               'InstanceType': 'm4.large',
-                                               'Market': 'ON_DEMAND',
-                                               'Name': 'Master Node'},
-                                              {'InstanceCount': 1,
-                                               'InstanceRole': 'CORE',
-                                               'InstanceType': 'm4.2xlarge',
-                                               'Market': 'ON_DEMAND',
-                                               'Name': 'Core Nodes'},
-                                              {'BidPrice': '0.1',
-                                               'InstanceCount': 1,
-                                               'InstanceRole': 'TASK',
-                                               'InstanceType': 'm4.2xlarge',
-                                               'Market': 'SPOT',
-                                               'Name': 'Task Nodes'}],
-                           'KeepJobFlowAliveWhenNoSteps': False,
-                           'TerminationProtected': False
-                           },
-                      'Applications': [{'Name': 'Hadoop'}, {'Name': 'Spark'}],
-                      'Configurations': [
-                          {
-                              'Classification': 'spark-defaults',
-                              'Properties': {
-                                  'spark.speculation': 'false'
-                              }
-                          },
-                          {
-                              'Classification': 'yarn-site',
-                              'Properties': {
-                                  'yarn.nodemanager.vmem-check-enabled': 'true'
-                              }
-                          }
-                      ],
-                      'Name': 'Test SparkSteps',
-                      'JobFlowRole': 'EMR_EC2_DefaultRole',
-                      'ReleaseLabel': 'emr-5.2.0',
-                      'VisibleToAllUsers': True,
-                      'ServiceRole': 'EMR_DefaultRole'}
+    assert config == {
+        'Instances': {
+            'InstanceGroups': [{'InstanceCount': 1,  # NOQA: E127
+                                'InstanceRole': 'MASTER',
+                                'InstanceType': 'm4.large',
+                                'Market': 'ON_DEMAND',
+                                'Name': 'Master Node'},
+                               {'InstanceCount': 1,
+                                'InstanceRole': 'CORE',
+                                'InstanceType': 'm4.2xlarge',
+                                'Market': 'ON_DEMAND',
+                                'Name': 'Core Nodes'},
+                               {'BidPrice': '0.1',
+                                'InstanceCount': 1,
+                                'InstanceRole': 'TASK',
+                                'InstanceType': 'm4.2xlarge',
+                                'Market': 'SPOT',
+                                'Name': 'Task Nodes'}],
+            'KeepJobFlowAliveWhenNoSteps': False,
+            'TerminationProtected': False
+        },
+        'Applications': [{'Name': 'Hadoop'}, {'Name': 'Spark'}],
+        'Configurations': [
+            {
+                'Classification': 'spark-defaults',
+                'Properties': {
+                    'spark.speculation': 'false'
+                }
+            },
+            {
+                'Classification': 'yarn-site',
+                'Properties': {
+                    'yarn.nodemanager.vmem-check-enabled': 'true'
+                }
+            }
+        ],
+        'Name': 'Test SparkSteps',
+        'JobFlowRole': 'EMR_EC2_DefaultRole',
+        'ReleaseLabel': 'emr-5.2.0',
+        'VisibleToAllUsers': True,
+        'ServiceRole': 'EMR_DefaultRole'
+    }
 
     client = boto3.client('emr', region_name=AWS_REGION_NAME)
     client.run_job_flow(**config)
@@ -251,14 +253,14 @@ def test_emr_ebs_storage():
                                                'Market': 'SPOT',
                                                'Name': 'Core Nodes',
                                                'EbsConfiguration': {
-                                               'EbsBlockDeviceConfigs': [{
-                                                    'VolumeSpecification': {
-                                                        'VolumeType': 'gp2',
-                                                        'SizeInGB': 100
-                                                    },
-                                                    'VolumesPerInstance': 2
-                                                }],
-                                                'EbsOptimized': False
+                                                   'EbsBlockDeviceConfigs': [{
+                                                       'VolumeSpecification': {
+                                                           'VolumeType': 'gp2',
+                                                           'SizeInGB': 100
+                                                       },
+                                                       'VolumesPerInstance': 2
+                                                   }],
+                                                   'EbsOptimized': False
                                                }},
                                               {'BidPrice': '0.1',
                                                'InstanceCount': 4,
@@ -267,14 +269,14 @@ def test_emr_ebs_storage():
                                                'Market': 'SPOT',
                                                'Name': 'Task Nodes',
                                                'EbsConfiguration': {
-                                               'EbsBlockDeviceConfigs': [{
-                                                    'VolumeSpecification': {
-                                                        'VolumeType': 'io1',
-                                                        'SizeInGB': 10
-                                                    },
-                                                    'VolumesPerInstance': 1
-                                                }],
-                                                'EbsOptimized': True
+                                                   'EbsBlockDeviceConfigs': [{
+                                                       'VolumeSpecification': {
+                                                           'VolumeType': 'io1',
+                                                           'SizeInGB': 10
+                                                       },
+                                                       'VolumesPerInstance': 1
+                                                   }],
+                                                   'EbsOptimized': True
                                                }}],
                            'KeepJobFlowAliveWhenNoSteps': False,
                            'TerminationProtected': False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,flake8,py35,py36,py37
+envlist = docs,flake8,py36,py37,py38
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
If the spot price for a particular instance type was close to half of the on-demand instance price, then determine_best_price() would incorrectly attempt to bid half of the on-demand price, even though that could be lower than the current spot price. This could lead to clusters not being provisioned with any instances.

While being at it I also made use of the opportunity to drop support for Python 3.5 which will be EOL as of 2020-09-13. In return of dropping support for Python 3.5, I've verified that this project works as expected under Python 3.8.
