### PR TITLE
Fix escaping of the '$' sign in the release recipe.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-build:
 
 .PHONY: clean-test
 clean-test:
-	find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+	find . | grep -E "(__pycache__|\.pyc|\.pyo$$)" | xargs rm -rf
 	rm -rf .pytest_cache/
 
 .PHONY: clean-eggs


### PR DESCRIPTION
The dollar sign needs to be escaped, otherwise Make will interpret as a variable.