### PR TITLE
Fixed a bug where the bid price would be based on prices in the wrong AZ

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Changelog
 Releases
 --------
 
+v3.0.1 (2020-12-23)
+~~~~~~~~~~~~~~~~~~~
+
+* Fixed an issue where `get_bid_price` would always base the instance bid price on the zone with the lowest current instance price, even though the cluster may not be launched in that AZ.
+
 v3.0.0 (2020-08-20)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -171,10 +171,10 @@ def determine_prices(args, ec2, pricing_client):
         return args
 
     availability_zone = None
-    if 'ec2_subnet_id' in args and args['ec2_subnet_id']:
+    subnet_id = args.get('ec2_subnet_id')
+    if subnet_id:
         # We need to determine the AZ associated with the provided EC2 subnet ID
         # in order to look up spot prices in the correct region.
-        subnet_id = args['ec2_subnet_id']
         availability_zone = pricing.get_availability_zone(ec2, subnet_id)
         if not availability_zone:
             logger.info("Could not determine availability zone for subnet '%s'", subnet_id)

--- a/sparksteps/__main__.py
+++ b/sparksteps/__main__.py
@@ -170,6 +170,15 @@ def determine_prices(args, ec2, pricing_client):
     if not any([x in args for x in pricing_properties]):
         return args
 
+    availability_zone = None
+    if 'ec2_subnet_id' in args and args['ec2_subnet_id']:
+        # We need to determine the AZ associated with the provided EC2 subnet ID
+        # in order to look up spot prices in the correct region.
+        subnet_id = args['ec2_subnet_id']
+        availability_zone = pricing.get_availability_zone(ec2, subnet_id)
+        if not availability_zone:
+            logger.info("Could not determine availability zone for subnet '%s'", subnet_id)
+
     # Mutate a copy of args.
     args = args.copy()
 
@@ -186,7 +195,7 @@ def determine_prices(args, ec2, pricing_client):
             instance_group = price_property.replace('dynamic_pricing_', '')
             # TODO (rikheijdens): optimize by caching instance prices
             # between instance groups?
-            bid_price, is_spot = pricing.get_bid_price(ec2, pricing_client, instance_type)
+            bid_price, is_spot = pricing.get_bid_price(ec2, pricing_client, instance_type, availability_zone)
             if is_spot:
                 logger.info("Using spot pricing with a bid price of $%.2f"
                             " for %s instances in the %s instance group.",

--- a/sparksteps/pricing.py
+++ b/sparksteps/pricing.py
@@ -51,6 +51,26 @@ def get_demand_price(pricing_client, instance_type, region='US East (N. Virginia
     return float(on_demand[index_1]['priceDimensions'][index_2]['pricePerUnit']['USD'])
 
 
+def get_availability_zone(ec2_client, subnet_id):
+    """
+    Returns the availability zone associated with the provided `subnet_id`.
+
+    Args:
+        ec2_client: Boto3 EC2 client.
+        subnet_id (str): The identifier of the subnet to look the associated AZ up for.
+
+    Returns:
+        AZ: The AvailabilityZone of the associated subnet.
+    """
+    response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
+    subnets = response.get('Subnets', [])
+    for s in subnets:
+        if s['SubnetId'] == subnet_id:
+            return s['AvailabilityZone']
+    # Could not determine the associated AZ.
+    return None
+
+
 def get_spot_price_history(ec2_client, instance_type, lookback=1):
     """Return dictionary of price history by availability zone.
 
@@ -111,15 +131,17 @@ def determine_best_price(demand_price, aws_zone):
     return min(1.2 * aws_zone.max, demand_price * SPOT_DEMAND_THRESHOLD_FACTOR), True
 
 
-def get_bid_price(ec2_client, pricing_client, instance_type):
+def get_bid_price(ec2_client, pricing_client, instance_type, availability_zone=None):
     """Determine AWS bid price.
 
     Args:
-        client: boto3 client
+        ec2_client: boto3 EC2 client
         instance_type: EC2 instance type
+        availability_zone: The availability zone the instance should be launched in,
+         if not provided an AZ is automatically selected.
 
     Returns:
-        float: bid price, bool: is stop
+        float: bid price, bool: is_spot
 
     Examples:
         >>> import boto3
@@ -128,7 +150,19 @@ def get_bid_price(ec2_client, pricing_client, instance_type):
     """
     history = get_spot_price_history(ec2_client, instance_type, SPOT_PRICE_LOOKBACK)
     by_zone = price_by_zone(history)
-    zone_profile = get_zone_profile(by_zone)
+    if availability_zone:
+        # Consider only the AZ in which we expect to launch instances.
+        zone_profile = get_zone_profile({availability_zone: by_zone.get(availability_zone, [])})
+    else:
+        # Consider all AZ's.
+        zone_profile = get_zone_profile(by_zone)
+    if not zone_profile:
+        # Unable to determine the spot price because no information was available for the
+        # desired AZ.
+        logger.info(
+            "Unable to determine the spot price for %s instances in %s because no "
+            "zone information was available.", instance_type, availability_zone)
+        return get_demand_price(pricing_client, instance_type)
     best_zone = min(zone_profile, key=lambda x: x.max)
     demand_price = get_demand_price(pricing_client, instance_type)
     bid_price, is_spot = determine_best_price(demand_price, best_zone)


### PR DESCRIPTION
This PR fixes a bug where the spot pricing logic in `get_bid_price()` would base the bid on the AZ which currently provides the lowest instance price.

However, if an EC2 Subnet ID is provided, then we can only bid on instances that will be launched in the Availability Zone that is
associated with the provided EC2 Subnet ID, which means that prices in other subnets should be ignored.

This bug could lead to a situation where the bids placed by sparksteps are too low to allow the cluster to launch.