### PR TITLE
Fix tests not being ran against master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - $default-branch
+      - master
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
Apparently, the `$default-branch` macro only works for GitHub Actions [workflow templates](https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization#creating-a-workflow-template). Which means that we need to be a bit more explicit here.